### PR TITLE
fix: Bound protobuf as CirQ breaks with protobuf > 4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.8,!=3.9.7,<3.11
 
 install_requires =
     #This is to fix unbounded dependency in cirq 0.13
-    protobuf<4,
+    protobuf<4
     cirq-core<=0.13
     cirq-google<=0.13
     orquestra-quantum

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ packages = find_namespace:
 python_requires = >=3.8,!=3.9.7,<3.11
 
 install_requires =
+    #This is to fix unbounded dependency in cirq 0.13
+    protobuf<4,
     cirq-core<=0.13
     cirq-google<=0.13
     orquestra-quantum


### PR DESCRIPTION
## Description

Release of protobuf 4 broke CirQ as it didn't have an upper bound. This fixes it.

Error trace:
```
my_little_venv/lib/python3.8/site-packages/orquestra/integrations/cirq/simulator/__init__.py:4: in <module>
    from .simulator import CirqSimulator
my_little_venv/lib/python3.8/site-packages/orquestra/integrations/cirq/simulator/simulator.py:7: in <module>
    import cirq
my_little_venv/lib/python3.8/site-packages/cirq/__init__.py:626: in <module>
    _compat.deprecated_submodule(
my_little_venv/lib/python3.8/site-packages/cirq/_compat.py:626: in deprecated_submodule
    new_module = importlib.import_module(new_module_name)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
my_little_venv/lib/python3.8/site-packages/cirq_google/__init__.py:17: in <module>
    from cirq_google import api
my_little_venv/lib/python3.8/site-packages/cirq_google/api/__init__.py:16: in <module>
    from cirq_google.api import v2
my_little_venv/lib/python3.8/site-packages/cirq_google/api/v2/__init__.py:16: in <module>
    from cirq_google.api.v2 import (
my_little_venv/lib/python3.8/site-packages/cirq_google/api/v2/batch_pb2.py:14: in <module>
    from . import program_pb2 as cirq__google_dot_api_dot_v2_dot_program__pb2
my_little_venv/lib/python3.8/site-packages/cirq_google/api/v2/program_pb2.py:34: in <module>
    _descriptor.EnumValueDescriptor(
my_little_venv/lib/python3.8/site-packages/google/protobuf/descriptor.py:755: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
E   
E   More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

## Please verify that you have completed the following steps

- [ ] I have self-reviewed my code.
- [ ] I have updated documentation.
