### PR TITLE
build: architecture of the simulators are simplified

### DIFF
--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -21,7 +21,16 @@ from ..conversions import export_to_cirq
 
 
 def _prepare_measurable_cirq_circuit(circuit, noise_model):
-    """Export circuit to Cirq and add terminal measurements."""
+    """
+    Export circuit to Cirq and add terminal measurements.
+
+    Args:
+        circuit (orquestra.quantum.circuit.Circuit): the circuit to prepare the state.
+        noise_model: model to create a noisy circuit
+
+    Returns:
+        circuit to run on a cirq or qsim simulator
+    """
     cirq_circuit = export_to_cirq(circuit)
 
     if noise_model is not None:
@@ -41,9 +50,17 @@ class CirqBasedSimulator(QuantumSimulator):
         self,
         simulator,
         noise_model=None,
-        param_resolver: "cirq.ParamResolverOrSimilarType" = None,
+        param_resolver: cirq.ParamResolverOrSimilarType = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
     ):
+        """initializes the parameters for the system or simulator
+
+        Args:
+            simulator: qsim or cirq simulator that is defined by the user
+            noise_model: optional argument to define the noise model
+            param_resolver: Optional arg that defines the parameters to run with the program.
+            qubit_order: Optional arg that defines the ordering of qubits.
+        """
         super().__init__()
         self.noise_model = noise_model
         self.simulator = simulator

--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -37,10 +37,18 @@ class CirqBasedSimulator(QuantumSimulator):
     supports_batching = True
     batch_size = sys.maxsize
 
-    def __init__(self, simulator, noise_model=None):
+    def __init__(
+        self,
+        simulator,
+        noise_model=None,
+        param_resolver: "cirq.ParamResolverOrSimilarType" = None,
+        qubit_order=cirq.ops.QubitOrder.DEFAULT,
+    ):
         super().__init__()
         self.noise_model = noise_model
         self.simulator = simulator
+        self.param_resolver = param_resolver
+        self.qubit_order = qubit_order
 
     def run_circuit_and_measure(self, circuit: Circuit, n_samples: int) -> Measurements:
         """Run a circuit and measure a certain number of bitstrings.
@@ -56,6 +64,7 @@ class CirqBasedSimulator(QuantumSimulator):
 
         result_object = self.simulator.run(
             _prepare_measurable_cirq_circuit(circuit, self.noise_model),
+            param_resolver=self.param_resolver,
             repetitions=n_samples,
         )
 
@@ -179,15 +188,24 @@ class CirqBasedSimulator(QuantumSimulator):
                 values.append(expectation_value)
         return expectation_values_to_real(ExpectationValues(np.asarray(values)))
 
-    @abc.abstractmethod
     def _get_wavefunction_from_native_circuit(
         self, circuit: Circuit, initial_state: StateVector
     ) -> StateVector:
-        pass
+        cirq_circuit = cast(cirq.Circuit, export_to_cirq(circuit))
 
-    @abc.abstractmethod
+        initial_state = np.array(initial_state, np.complex64)
+
+        simulated_result = self.simulator.simulate(
+            cirq_circuit,
+            param_resolver=self.param_resolver,
+            qubit_order=self.qubit_order,
+            initial_state=initial_state,
+        )
+
+        return simulated_result.final_state_vector
+
     def _extract_density_matrix(self, result):
-        pass
+        return result.density_matrix_of()
 
 
 def get_measurement_from_cirq_result_object(

--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -58,7 +58,8 @@ class CirqBasedSimulator(QuantumSimulator):
         Args:
             simulator: qsim or cirq simulator that is defined by the user
             noise_model: optional argument to define the noise model
-            param_resolver: Optional arg that defines the parameters to run with the program.
+            param_resolver: Optional arg that defines the parameters
+            to run with the program.
             qubit_order: Optional arg that defines the ordering of qubits.
         """
         super().__init__()

--- a/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
@@ -43,14 +43,12 @@ class QSimSimulator(CirqBasedSimulator):
     def __init__(
         self,
         noise_model=None,
-        seed=None,
-        param_resolver=None,
+        param_resolver: "cirq.ParamResolverOrSimilarType" = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         circuit_memoization_size: int = 0,
         qsim_options: Optional[Union[Dict, qsimcirq.QSimOptions]] = None,
     ):
-        self.qubit_order = qubit_order
-        self.param_resolver = param_resolver
 
         simulator = qsimcirq.QSimSimulator(
             qsim_options=qsim_options,
@@ -58,32 +56,4 @@ class QSimSimulator(CirqBasedSimulator):
             circuit_memoization_size=circuit_memoization_size,
         )
 
-        super().__init__(simulator, noise_model)
-
-    def _get_wavefunction_from_native_circuit(
-        self, circuit: Circuit, initial_state: StateVector
-    ) -> StateVector:
-        """Return the state vector at the end of the computation
-        Args:
-            circuit: the circuit to prepare the state
-            initial_state: initial state of the system
-
-        Returns:
-            StateVector: Returns the final state of the computation as ndarray
-
-        """
-        cirq_circuit = cast(cirq.Circuit, export_to_cirq(circuit))
-
-        initial_state = np.array(initial_state, np.complex64)
-
-        simulated_result = self.simulator.simulate(
-            cirq_circuit,
-            param_resolver=self.param_resolver,
-            qubit_order=self.qubit_order,
-            initial_state=initial_state,
-        )
-
-        return simulated_result.final_state_vector
-
-    def _extract_density_matrix(self, result):
-        return result.density_matrix_of()
+        super().__init__(simulator, noise_model, param_resolver, qubit_order)

--- a/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
@@ -22,19 +22,24 @@ class QSimSimulator(CirqBasedSimulator):
 
     Args:
         noise_model: an optional noise model to pass in for noisy simulations
-        seed: seed for random number generator.
         param_resolver: Optional arg that defines the
         parameters to run with the program.
         qubit_order: Optional arg that defines the ordering of qubits.
+        seed: seed for random number generator.
         circuit_memoization_size: Optional arg tht defines the number of
         last translated circuits to be memoized from simulation executions,
         to eliminate translation overhead.
+        qsim_options:  An options dict or QSimOptions object with options
+        to use for all circuits run using this simulator. See QSimOptions from
+        qsimcirq for more details.
 
     Attributes:
+        simulator: Qsim simulator this class uses with the options defined.
         noise_model: an optional noise model to pass in for noisy simulations
         qubit_order: qubit_order: Optional arg that defines the ordering of qubits.
         param_resolver: param_resolver: Optional arg that defines the
         parameters to run with the program.
+        qubit_order: Optional arg that defines the ordering of qubits.
     """
 
     supports_batching = True
@@ -43,7 +48,7 @@ class QSimSimulator(CirqBasedSimulator):
     def __init__(
         self,
         noise_model=None,
-        param_resolver: "cirq.ParamResolverOrSimilarType" = None,
+        param_resolver: Optional[cirq.ParamResolverOrSimilarType] = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         circuit_memoization_size: int = 0,

--- a/src/orquestra/integrations/cirq/simulator/simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/simulator.py
@@ -19,16 +19,19 @@ class CirqSimulator(CirqBasedSimulator):
 
     """Simulator using a cirq device (simulator or QPU).
 
-    Currently this Simulator uses cirq.Simulator if noise_model is None and
-    cirq.DensityMatrixSimulator otherwise.
-
     Args:
         noise_model: an optional noise model to pass in for noisy simulations
         seed: seed for random number generator.
+        param_resolver: Optional arg that defines the
+        parameters to run with the program.
+        qubit_order: Optional arg that defines the ordering of qubits.
 
     Attributes:
         noise_model: an optional noise model to pass in for noisy simulations
         simulator: Cirq simulator this class uses.
+        param_resolver: Optional arg that defines the
+        parameters to run with the program.
+        qubit_order: Optional arg that defines the ordering of qubits.
     """
 
     supports_batching = True

--- a/src/orquestra/integrations/cirq/simulator/simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/simulator.py
@@ -34,23 +34,13 @@ class CirqSimulator(CirqBasedSimulator):
     supports_batching = True
     batch_size = sys.maxsize
 
-    def __init__(self, noise_model=None, seed: int = None):
-        simulator = (
-            cirq.DensityMatrixSimulator(dtype=np.complex128, seed=seed)
-            if noise_model is not None
-            else cirq.Simulator(seed=seed)
-        )
+    def __init__(
+        self,
+        noise_model=None,
+        seed: int = None,
+        param_resolver: "cirq.ParamResolverOrSimilarType" = None,
+        qubit_order=cirq.ops.QubitOrder.DEFAULT,
+    ):
+        simulator = cirq.Simulator(seed=seed)
 
-        super().__init__(simulator, noise_model)
-
-    def _get_wavefunction_from_native_circuit(
-        self, circuit: Circuit, initial_state: StateVector
-    ) -> StateVector:
-
-        cirq_circuit = cast(cirq.Circuit, export_to_cirq(circuit))
-        return cirq_circuit.final_state_vector(
-            initial_state=cast(cirq.STATE_VECTOR_LIKE, initial_state)
-        )
-
-    def _extract_density_matrix(self, result):
-        return result.final_density_matrix
+        super().__init__(simulator, noise_model, param_resolver, qubit_order)

--- a/tests/orquestra/integrations/cirq/simulator/simulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/simulator_test.py
@@ -110,7 +110,9 @@ class TestCirqSimulator(QuantumSimulatorTests):
         expectation_values = simulator.get_exact_noisy_expectation_values(
             circuit, qubit_operator
         )
-        np.testing.assert_almost_equal(expectation_values.values[0], target_values[0])
+        np.testing.assert_almost_equal(
+            expectation_values.values[0], target_values[0], 2
+        )
         np.testing.assert_almost_equal(expectation_values.values[1], target_values[1])
 
     def test_run_circuit_and_measure_seed(self):
@@ -143,4 +145,5 @@ class TestCirqSimulator(QuantumSimulatorTests):
 
 
 class TestCirqSimulatorGates(QuantumSimulatorGatesTest):
+    atol_wavefunction = 1e-8
     pass


### PR DESCRIPTION
## Description

Include description of feature this PR introduces or a bug that it fixes. Include the following information:

Changed the architecture to simplify inheritance and upgrade the function to match the new cirq version. Both Qsim and Cirq now share the same base simulator. 

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have included test cases validating introduced feature/fix.
- [X] I have updated documentation.
