### PR TITLE
fix: qsim_options optional intake bug fixed

### DIFF
--- a/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
@@ -55,7 +55,7 @@ class QSimSimulator(CirqBasedSimulator):
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         circuit_memoization_size: int = 0,
-        qsim_options: Optional[Union[Dict, "qsimcirq.QSimOptions"]] = None,
+        qsim_options: Optional["qsimcirq.QSimOptions"] = None,
     ):
 
         simulator = qsimcirq.QSimSimulator(


### PR DESCRIPTION
## Description

Include description of feature this PR introduces or a bug that it fixes. Include the following information:

QSimOptions and QSimSimulator do not take gpu options in the same format. In order to minimize the confusion among the users, I have modified to only accept one format that is used by both function. 

More details: https://github.com/quantumlib/qsim/blob/6443786bd1f283cbfa8d25151100a9ae640e3807/qsimcirq/qsim_simulator.py#L152

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have included test cases validating introduced feature/fix.
- [X] I have updated documentation.
