### PR TITLE
feat: add typing for cirq noise model

### DIFF
--- a/src/orquestra/integrations/cirq/noise/basic.py
+++ b/src/orquestra/integrations/cirq/noise/basic.py
@@ -6,6 +6,11 @@ from typing import Dict, Union
 
 import numpy as np
 from cirq import (
+    NOISE_MODEL_LIKE,
+    AmplitudeDampingChannel,
+    AsymmetricDepolarizingChannel,
+    DepolarizingChannel,
+    PhaseDampingChannel,
     amplitude_damp,
     asymmetric_depolarize,
     depolarize,
@@ -14,7 +19,7 @@ from cirq import (
 )
 
 
-def get_depolarizing_channel(T, t_gate=10e-9):
+def get_depolarizing_channel(T: float, t_gate: float = 10e-9) -> DepolarizingChannel:
     """Get the depolarizing channel
 
     Args:
@@ -29,7 +34,9 @@ def get_depolarizing_channel(T, t_gate=10e-9):
     return noise_model
 
 
-def get_asymmetric_depolarize(T_1: float, T_2: float, t_gate: float = 10e-9):
+def get_asymmetric_depolarize(
+    T_1: float, T_2: float, t_gate: float = 10e-9
+) -> AsymmetricDepolarizingChannel:
     """Creates a noise model that does both phase and amplitude damping but in the
         Pauli Twirling Approximation discussed in the following reference
         https://arxiv.org/pdf/1305.2021.pdf
@@ -71,7 +78,7 @@ def get_asymmetric_depolarize(T_1: float, T_2: float, t_gate: float = 10e-9):
     return noise_model
 
 
-def get_amplitude_damping(T_1: float, t_gate: float = 10e-9):
+def get_amplitude_damping(T_1: float, t_gate: float = 10e-9) -> AmplitudeDampingChannel:
     """Creates an amplitude damping noise model
 
     Args:
@@ -87,7 +94,7 @@ def get_amplitude_damping(T_1: float, t_gate: float = 10e-9):
     return noise_model
 
 
-def get_phase_damping(T_2: float, t_gate: float = 10e-9):
+def get_phase_damping(T_2: float, t_gate: float = 10e-9) -> PhaseDampingChannel:
     """Creates a dephasing noise model
 
     Args:
@@ -107,7 +114,7 @@ def get_phase_damping(T_2: float, t_gate: float = 10e-9):
 }
 
 
-def load_noise_model_from_json(serialized_model: Union[Dict, str]):
+def load_noise_model_from_json(serialized_model: Union[Dict, str]) -> NOISE_MODEL_LIKE:
     """Loads a cirq noise model (version 2)
 
     Args:

--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -2,9 +2,8 @@
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
 
-import abc
 import sys
-from typing import List, Sequence, Union, cast
+from typing import List, Sequence, cast
 
 import cirq
 import numpy as np
@@ -49,7 +48,7 @@ class CirqBasedSimulator(QuantumSimulator):
     def __init__(
         self,
         simulator,
-        noise_model=None,
+        noise_model: cirq.NOISE_MODEL_LIKE = None,
         param_resolver: cirq.ParamResolverOrSimilarType = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
     ):

--- a/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
@@ -3,7 +3,7 @@
 ################################################################################
 import sys
 import warnings
-from typing import Dict, List, Optional, Union
+from typing import Optional
 
 import cirq
 
@@ -50,7 +50,7 @@ class QSimSimulator(CirqBasedSimulator):
 
     def __init__(
         self,
-        noise_model=None,
+        noise_model: cirq.NOISE_MODEL_LIKE = None,
         param_resolver: Optional[cirq.ParamResolverOrSimilarType] = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,

--- a/src/orquestra/integrations/cirq/simulator/simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/simulator.py
@@ -32,7 +32,7 @@ class CirqSimulator(CirqBasedSimulator):
 
     def __init__(
         self,
-        noise_model=None,
+        noise_model: cirq.NOISE_MODEL_LIKE = None,
         seed: int = None,
         param_resolver: "cirq.ParamResolverOrSimilarType" = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,


### PR DESCRIPTION
## Description

Added typing for cirq noise model.

The common channels are defined [here](https://github.com/quantumlib/Cirq/blob/v0.14.1/cirq-core/cirq/ops/common_channels.py).

`NOISE_MODEL_LIKE` is defined [here](https://github.com/quantumlib/Cirq/blob/v0.14.1/cirq-core/cirq/devices/noise_model.py#L267). This is what cirq uses for their typing for noise model in `with_noise()` [here](https://github.com/quantumlib/Cirq/blob/v0.14.1/cirq-core/cirq/circuits/circuit.py#L2434).

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
