### PR TITLE
QSimSimulator can normalise the resulting statevec from a circuit run

### DIFF
--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -65,6 +65,8 @@ class CirqBasedSimulator(QuantumSimulator):
             param_resolver: Optional arg that defines the parameters
             to run with the program.
             qubit_order: Optional arg that defines the ordering of qubits.
+            normalize: whether to normalize the state vector after
+                simulation of the quantum circuit, by default False.
         """
         super().__init__()
         self.noise_model = noise_model

--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -55,7 +55,7 @@ class CirqBasedSimulator(QuantumSimulator):
         noise_model: cirq.NOISE_MODEL_LIKE = None,
         param_resolver: cirq.ParamResolverOrSimilarType = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
-        normalize: bool = False,
+        normalize_wavefunction: bool = False,
     ):
         """initializes the parameters for the system or simulator
 
@@ -65,7 +65,7 @@ class CirqBasedSimulator(QuantumSimulator):
             param_resolver: Optional arg that defines the parameters
             to run with the program.
             qubit_order: Optional arg that defines the ordering of qubits.
-            normalize: whether to normalize the state vector after
+            normalize_wavefunction: whether to normalize the state vector after
                 simulation of the quantum circuit, by default False.
         """
         super().__init__()
@@ -73,7 +73,7 @@ class CirqBasedSimulator(QuantumSimulator):
         self.simulator = simulator
         self.param_resolver = param_resolver
         self.qubit_order = qubit_order
-        self.normalize = normalize
+        self.normalize_wavefunction = normalize_wavefunction
 
     def run_circuit_and_measure(self, circuit: Circuit, n_samples: int) -> Measurements:
         """Run a circuit and measure a certain number of bitstrings.
@@ -227,7 +227,7 @@ class CirqBasedSimulator(QuantumSimulator):
             initial_state=initial_state,
         )
         final_state_vector = np.asarray(simulated_result.final_state_vector)
-        if self.normalize:
+        if self.normalize_wavefunction:
             final_state_vector /= np.linalg.norm(final_state_vector)
         return final_state_vector
 

--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -228,6 +228,7 @@ class CirqBasedSimulator(QuantumSimulator):
         )
         final_state_vector = np.asarray(simulated_result.final_state_vector)
         if self.normalize_wavefunction:
+            final_state_vector = final_state_vector.astype(np.complex256)
             final_state_vector /= np.linalg.norm(final_state_vector)
         return final_state_vector
 

--- a/src/orquestra/integrations/cirq/simulator/_base.py
+++ b/src/orquestra/integrations/cirq/simulator/_base.py
@@ -55,6 +55,7 @@ class CirqBasedSimulator(QuantumSimulator):
         noise_model: cirq.NOISE_MODEL_LIKE = None,
         param_resolver: cirq.ParamResolverOrSimilarType = None,
         qubit_order=cirq.ops.QubitOrder.DEFAULT,
+        normalize: bool = False,
     ):
         """initializes the parameters for the system or simulator
 
@@ -70,6 +71,7 @@ class CirqBasedSimulator(QuantumSimulator):
         self.simulator = simulator
         self.param_resolver = param_resolver
         self.qubit_order = qubit_order
+        self.normalize = normalize
 
     def run_circuit_and_measure(self, circuit: Circuit, n_samples: int) -> Measurements:
         """Run a circuit and measure a certain number of bitstrings.
@@ -222,8 +224,10 @@ class CirqBasedSimulator(QuantumSimulator):
             qubit_order=self.qubit_order,
             initial_state=initial_state,
         )
-
-        return simulated_result.final_state_vector
+        final_state_vector = np.asarray(simulated_result.final_state_vector)
+        if self.normalize:
+            final_state_vector /= np.linalg.norm(final_state_vector)
+        return final_state_vector
 
     def _extract_density_matrix(self, result):
         return result.density_matrix_of()

--- a/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
@@ -35,6 +35,12 @@ class QSimSimulator(CirqBasedSimulator):
         qsim_options:  An options dict or QSimOptions object with options
             to use for all circuits run using this simulator. See QSimOptions from
             qsimcirq for more details.
+        normalize_wavefunction: Whether to normalize the state vector after
+            simulation of the quantum circuit, by default False. This flag is
+            exposed because sometimes, the resulting state vector from a qsim
+            circuit simulation is not normalized up to machine precision, which
+            can cause issues with some applications such as sampling using a
+            probability vector.
 
     Attributes:
         simulator: Qsim simulator this class uses with the options defined.
@@ -56,7 +62,7 @@ class QSimSimulator(CirqBasedSimulator):
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         circuit_memoization_size: int = 0,
         qsim_options: Optional["qsimcirq.QSimOptions"] = None,
-        normalize: bool = False,
+        normalize_wavefunction: bool = False,
     ):
 
         simulator = qsimcirq.QSimSimulator(
@@ -65,4 +71,6 @@ class QSimSimulator(CirqBasedSimulator):
             circuit_memoization_size=circuit_memoization_size,
         )
 
-        super().__init__(simulator, noise_model, param_resolver, qubit_order, normalize)
+        super().__init__(
+            simulator, noise_model, param_resolver, qubit_order, normalize_wavefunction
+        )

--- a/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
+++ b/src/orquestra/integrations/cirq/simulator/qsim_simulator.py
@@ -56,6 +56,7 @@ class QSimSimulator(CirqBasedSimulator):
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         circuit_memoization_size: int = 0,
         qsim_options: Optional["qsimcirq.QSimOptions"] = None,
+        normalize: bool = False,
     ):
 
         simulator = qsimcirq.QSimSimulator(
@@ -64,4 +65,4 @@ class QSimSimulator(CirqBasedSimulator):
             circuit_memoization_size=circuit_memoization_size,
         )
 
-        super().__init__(simulator, noise_model, param_resolver, qubit_order)
+        super().__init__(simulator, noise_model, param_resolver, qubit_order, normalize)

--- a/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
@@ -108,7 +108,11 @@ class TestQsimSimulator(QuantumSimulatorTests):
             np.sum(np.abs(normalized_wavefunction.amplitudes) ** 2) - 1.0
         )
         # Then
-        assert np.isclose(precision_error_without_normalization, 0.0)
+        assert np.isclose(
+            precision_error_without_normalization,
+            0.0,
+            atol=TestQSimSimulatorGates.atol_wavefunction,
+        )
         assert np.isclose(precision_error_with_normalization, 0.0, atol=1e-16)
 
     def test_get_exact_expectation_values(self):

--- a/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
@@ -93,6 +93,19 @@ class TestQsimSimulator(QuantumSimulatorTests):
             wavefunction.amplitudes[7], (1 / np.sqrt(2) + 0j), atol=10e-15
         )
 
+    def test_normalization(self):
+        # Given
+        simulator1 = QSimSimulator()
+        simulator2 = QSimSimulator(normalize_wavefunction=True)
+        circuit = Circuit([H(0), CNOT(0, 1), CNOT(1, 2)])
+        # When
+        wavefunction = simulator1.get_wavefunction(circuit)
+        normalized_wavefunction = simulator2.get_wavefunction(circuit)
+        # Then
+        assert abs(
+            np.sum(np.abs(normalized_wavefunction.amplitudes) ** 2) - 1.0
+        ) <= abs(np.sum(np.abs(wavefunction.amplitudes) ** 2) - 1.0)
+
     def test_get_exact_expectation_values(self):
         # Given
         simulator = QSimSimulator()

--- a/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
@@ -95,7 +95,7 @@ class TestQsimSimulator(QuantumSimulatorTests):
 
     def test_normalization(self):
         # Given
-        simulator1 = QSimSimulator()
+        simulator1 = QSimSimulator(normalize_wavefunction=False)
         simulator2 = QSimSimulator(normalize_wavefunction=True)
         circuit = Circuit([H(0), CNOT(0, 1), CNOT(1, 2)])
         # When

--- a/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
@@ -101,10 +101,15 @@ class TestQsimSimulator(QuantumSimulatorTests):
         # When
         wavefunction = simulator1.get_wavefunction(circuit)
         normalized_wavefunction = simulator2.get_wavefunction(circuit)
-        # Then
-        assert abs(
+        precision_error_without_normalization = abs(
+            np.sum(np.abs(wavefunction.amplitudes) ** 2) - 1.0
+        )
+        precision_error_with_normalization = abs(
             np.sum(np.abs(normalized_wavefunction.amplitudes) ** 2) - 1.0
-        ) <= abs(np.sum(np.abs(wavefunction.amplitudes) ** 2) - 1.0)
+        )
+        # Then
+        assert np.isclose(precision_error_without_normalization, 0.0)
+        assert np.isclose(precision_error_with_normalization, 0.0, atol=1e-16)
 
     def test_get_exact_expectation_values(self):
         # Given

--- a/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/qsimsimulator_test.py
@@ -113,7 +113,7 @@ class TestQsimSimulator(QuantumSimulatorTests):
             0.0,
             atol=TestQSimSimulatorGates.atol_wavefunction,
         )
-        assert np.isclose(precision_error_with_normalization, 0.0, atol=1e-16)
+        assert np.isclose(precision_error_with_normalization, 0.0, atol=1e-15)
 
     def test_get_exact_expectation_values(self):
         # Given


### PR DESCRIPTION
## Description

`QSimSimulator` does not preserve probability up to the required resolution by `numpy.random.choice`, meaning that sometimes the output statevector from a circuit simulated with `QSimSimulator` ends up with a total probability slightly below or above 1.

This PR adds a flag to `QSimSimulator` that allows normalisation after a circuit run, so that the norm is 1 up to machine precision.

Closes https://github.com/zapatacomputing/orquestra-qml-core/issues/377.

Include description of feature this PR introduces or a bug that it fixes. Include the following information:

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
