### PR TITLE
feat(circuit_conversions): allow NamedQubits in imported circuits

### DIFF
--- a/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
+++ b/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
@@ -371,7 +371,7 @@ def _convert_gate_operation_to_orquestra(operation) -> _gates.GateOperation:
     if not all(isinstance(qubit, cirq.LineQubit) for qubit in operation.qubits):
         raise NotImplementedError(
             f"Failed to import {operation}. Only LineQubits are supported."
-            "for gates. Try converting NamedQubits inside a circuit instead."
+            "for gates. Try converting the Gate and adding qubits after."
         )
 
     imported_gate = _import_from_cirq(operation.gate)
@@ -392,26 +392,14 @@ def _convert_gate_operation_to_orquestra(operation) -> _gates.GateOperation:
 
 @_import_from_cirq.register
 def _import_circuit_from_cirq(circuit: cirq.Circuit) -> _circuit.Circuit:
-    has_grid_qubit = [
-        any(isinstance(qubit, cirq.GridQubit) for qubit in operation.qubits)
-        for operation in circuit.all_operations()
-    ]
-    if any(has_grid_qubit):
-        grid_qubit_operation = circuit.all_operations()[has_grid_qubit.index(True)]
-        raise NotImplementedError(
-            f"Failed to import {grid_qubit_operation}. GridQubits are not supported."
-        )
-    circuit = replace_named_qubits_with_line_qubits(circuit)
-    return _circuit.Circuit(
-        [_import_from_cirq(op) for op in chain.from_iterable(circuit.moments)]
-    )
-
-
-def replace_named_qubits_with_line_qubits(circuit: cirq.Circuit) -> cirq.Circuit:
     all_qubits = sorted(circuit.all_qubits())
     max_line_id = 0
     contains_line_qubit = False
     for qubit in all_qubits:
+        if isinstance(qubit, cirq.GridQubit):
+            raise NotImplementedError(
+                "Failed to import circuit. GridQubits are not supported."
+            )
         if isinstance(qubit, cirq.LineQubit):
             contains_line_qubit = True
             if qubit.x < 0:
@@ -427,5 +415,8 @@ def replace_named_qubits_with_line_qubits(circuit: cirq.Circuit) -> cirq.Circuit
         if isinstance(qubit, cirq.NamedQubit):
             qubit_map[qubit] = cirq.LineQubit(current_qubit_id)
             current_qubit_id += 1
+    circuit = circuit.transform_qubits(qubit_map)  # type: ignore
 
-    return circuit.transform_qubits(qubit_map)
+    return _circuit.Circuit(
+        [_import_from_cirq(op) for op in chain.from_iterable(circuit.moments)]
+    )

--- a/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
+++ b/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
@@ -370,8 +370,8 @@ def _gen_custom_gate_name(gate_cls, matrix: np.ndarray):
 def _convert_gate_operation_to_orquestra(operation) -> _gates.GateOperation:
     if not all(isinstance(qubit, cirq.LineQubit) for qubit in operation.qubits):
         raise NotImplementedError(
-            f"Failed to import {operation}. Only GateOperations on LineQubits "
-            "are supported. Try converting the Gate and adding qubits after."
+            f"Failed to import {operation}. Only GateOperations on LineQubits are"
+            "supported. Try converting the underlying Gate and adding qubits after."
         )
 
     imported_gate = _import_from_cirq(operation.gate)

--- a/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
+++ b/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
@@ -370,8 +370,8 @@ def _gen_custom_gate_name(gate_cls, matrix: np.ndarray):
 def _convert_gate_operation_to_orquestra(operation) -> _gates.GateOperation:
     if not all(isinstance(qubit, cirq.LineQubit) for qubit in operation.qubits):
         raise NotImplementedError(
-            f"Failed to import {operation}. Only LineQubits are supported."
-            "for gates. Try converting the Gate and adding qubits after."
+            f"Failed to import {operation}. Only GateOperations on LineQubits "
+            "are supported. Try converting the Gate and adding qubits after."
         )
 
     imported_gate = _import_from_cirq(operation.gate)

--- a/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
+++ b/src/orquestra/integrations/cirq/conversions/_circuit_conversions.py
@@ -283,8 +283,8 @@ def import_from_cirq(obj):
     result in custom gates. See `help(orquestra.quantum.circuits)` for examples of
     custom gates.
 
-    Also note that only objects using only LineQubits are supported, as currently there
-    is no notion of GridQubit in Orquestra circuits.
+    Also note that objects using GridQubits are never supported. NamedQubits are only
+    supported inside circuits, not as standalone Operations.
     """
     return _import_from_cirq(obj)
 
@@ -371,6 +371,7 @@ def _convert_gate_operation_to_orquestra(operation) -> _gates.GateOperation:
     if not all(isinstance(qubit, cirq.LineQubit) for qubit in operation.qubits):
         raise NotImplementedError(
             f"Failed to import {operation}. Only LineQubits are supported."
+            "for gates. Try converting NamedQubits inside a circuit instead."
         )
 
     imported_gate = _import_from_cirq(operation.gate)
@@ -391,6 +392,40 @@ def _convert_gate_operation_to_orquestra(operation) -> _gates.GateOperation:
 
 @_import_from_cirq.register
 def _import_circuit_from_cirq(circuit: cirq.Circuit) -> _circuit.Circuit:
+    has_grid_qubit = [
+        any(isinstance(qubit, cirq.GridQubit) for qubit in operation.qubits)
+        for operation in circuit.all_operations()
+    ]
+    if any(has_grid_qubit):
+        grid_qubit_operation = circuit.all_operations()[has_grid_qubit.index(True)]
+        raise NotImplementedError(
+            f"Failed to import {grid_qubit_operation}. GridQubits are not supported."
+        )
+    circuit = replace_named_qubits_with_line_qubits(circuit)
     return _circuit.Circuit(
         [_import_from_cirq(op) for op in chain.from_iterable(circuit.moments)]
     )
+
+
+def replace_named_qubits_with_line_qubits(circuit: cirq.Circuit) -> cirq.Circuit:
+    all_qubits = sorted(circuit.all_qubits())
+    max_line_id = 0
+    contains_line_qubit = False
+    for qubit in all_qubits:
+        if isinstance(qubit, cirq.LineQubit):
+            contains_line_qubit = True
+            if qubit.x < 0:
+                raise ValueError(
+                    f"LineQubit with negative index {qubit.x} is not supported."
+                )
+            if qubit.x > max_line_id:
+                max_line_id = qubit.x
+
+    qubit_map = {}
+    current_qubit_id = max_line_id + 1 if contains_line_qubit else 0
+    for qubit in all_qubits:
+        if isinstance(qubit, cirq.NamedQubit):
+            qubit_map[qubit] = cirq.LineQubit(current_qubit_id)
+            current_qubit_id += 1
+
+    return circuit.transform_qubits(qubit_map)

--- a/tests/orquestra/integrations/cirq/conversions/circuit_conversions_test.py
+++ b/tests/orquestra/integrations/cirq/conversions/circuit_conversions_test.py
@@ -5,13 +5,14 @@ import cirq
 import numpy as np
 import pytest
 import sympy
+from orquestra.quantum.circuits import _builtin_gates, _circuit, _gates
+from packaging.version import parse
+
 from orquestra.integrations.cirq.conversions._circuit_conversions import (
     export_to_cirq,
     import_from_cirq,
     make_rotation_factory,
 )
-from orquestra.quantum.circuits import _builtin_gates, _circuit, _gates
-from packaging.version import parse
 
 # --------- gates ---------
 

--- a/tests/orquestra/integrations/cirq/conversions/circuit_conversions_test.py
+++ b/tests/orquestra/integrations/cirq/conversions/circuit_conversions_test.py
@@ -5,14 +5,13 @@ import cirq
 import numpy as np
 import pytest
 import sympy
-from orquestra.quantum.circuits import _builtin_gates, _circuit, _gates
-from packaging.version import parse
-
 from orquestra.integrations.cirq.conversions._circuit_conversions import (
     export_to_cirq,
     import_from_cirq,
     make_rotation_factory,
 )
+from orquestra.quantum.circuits import _builtin_gates, _circuit, _gates
+from packaging.version import parse
 
 # --------- gates ---------
 
@@ -338,21 +337,61 @@ class TestImportingFromCirq:
         with pytest.raises(NotImplementedError):
             import_from_cirq(cirq_circuit)
 
-    def test_only_named_qubits_are_converted_to_labeled_qubit(self):
-        cirq_circuit = cirq.Circuit(cirq.X(cirq.NamedQubit("a")))
-        cirq_circuit += cirq.CNOT(cirq.NamedQubit("a"), cirq.NamedQubit("b"))
+    @pytest.mark.parametrize(
+        "cirq_circuit, num_qubits, target_labels",
+        [
+            (
+                cirq.Circuit(
+                    [
+                        cirq.X(cirq.NamedQubit("a")),
+                        cirq.CNOT(cirq.NamedQubit("a"), cirq.NamedQubit("b")),
+                    ]
+                ),
+                2,
+                [(0,), (0, 1)],
+            ),
+            (
+                cirq.Circuit(
+                    [
+                        cirq.X(cirq.LineQubit(0)),
+                        cirq.CNOT(cirq.NamedQubit("a"), cirq.NamedQubit("b")),
+                    ]
+                ),
+                3,
+                [(0,), (1, 2)],
+            ),
+            (
+                cirq.Circuit(
+                    [
+                        cirq.X(cirq.LineQubit(20)),
+                        cirq.X(cirq.NamedQubit("b")),
+                    ]
+                ),
+                22,
+                [(20,), (21,)],
+            ),
+            (
+                cirq.Circuit(
+                    [
+                        cirq.X(cirq.NamedQubit("a")),
+                        cirq.X(cirq.LineQubit(0)),
+                        cirq.X(cirq.NamedQubit("b")),
+                    ]
+                ),
+                3,
+                [(1,), (0,), (2,)],
+            ),
+        ],
+    )
+    def test_named_qubits_are_converted_to_labeled_qubit(
+        self, cirq_circuit, num_qubits, target_labels
+    ):
         circuit = import_from_cirq(cirq_circuit)
-        assert circuit.n_qubits == 2
-        assert circuit.operations[0].qubit_indices == (0,)
-        assert circuit.operations[1].qubit_indices == (0, 1)
-
-    def test_named_qubits_are_converted_to_labeled_qubit(self):
-        cirq_circuit = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
-        cirq_circuit += cirq.CNOT(cirq.NamedQubit("a"), cirq.NamedQubit("b"))
-        circuit = import_from_cirq(cirq_circuit)
-        assert circuit.n_qubits == 3
-        assert circuit.operations[0].qubit_indices == (0,)
-        assert circuit.operations[1].qubit_indices == (1, 2)
+        assert circuit.n_qubits == num_qubits
+        assert all(
+            target_label == operation.qubit_indices
+            for target_label, operation in zip(target_labels, circuit.operations)
+        )
 
     def test_named_qubit_in_gate_operation_throws_error(self):
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
## Description

Users can now use NamedQubits in imported circuits. However, NamedQubits still cannot be used when importing single GatesOperations. I made this design choice because importing a GateOperation on a NamedQubit means mapping it to a number, which might be inconsistent between imports. 

For instance, a GateOperation on NamedQubit("a") could get the same label as NamedQubit("b") if they are translated a different time. Instead, users should translate the Gate and then pick a qubit themselves rather than translating a GateOperation with a NamedQubit.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
