### PR TITLE
chore: Remove Python 3.11 upper bound

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: TestCoverage - Python ${{ matrix.python }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,10 @@ python_requires = >=3.9,!=3.9.7
 install_requires =
     #This is to fix unbounded dependency in cirq 0.13
     protobuf<4
-    cirq-core~=1.1.0
-    cirq-google~=1.1.0
+    cirq-core~=1.2.0
+    cirq-google~=1.2.0
     orquestra-quantum
-    openfermion~=1.4
+    openfermion~=1.5.1
 
 
 [options.packages.find]
@@ -36,7 +36,7 @@ where = src
 
 [options.extras_require]
 qsim =
-    qsimcirq ~=0.14.0
+    qsimcirq ~= 0.16.3
     
 dev =
     orquestra-python-dev

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7,<3.11
+python_requires = >=3.9,!=3.9.7
 install_requires =
     #This is to fix unbounded dependency in cirq 0.13
     protobuf<4


### PR DESCRIPTION
## Description

In order to allow Python versions newer than 3.10 we need to remove the upper bound.

This PR:
- allows Orquestra Cirq to work on 3.11 and later
- Updates Cirq and OpenFermion


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
