### PR TITLE
Delegate fixing pandas deprecation warnings

### DIFF
--- a/src/orquestra/integrations/cirq/_pandas_compat.py
+++ b/src/orquestra/integrations/cirq/_pandas_compat.py
@@ -1,0 +1,28 @@
+################################################################################
+# © Copyright 2024 Zapata Computing Inc.
+################################################################################
+"""Workaround for pandas 2.2.0 raising warning related to pyarrow. """
+
+import warnings
+
+
+def preload_pandas_without_warnings():
+    """Workaround for pandas 2.2.0 raising warning related to pyarrow.
+
+    Run this function before importing a module which depends on pandas
+    to avoid deprecation warnings.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+        # The warning's content:
+        #
+        # DeprecationWarning:
+        # Pyarrow will become a required dependency of pandas in the next majorrelease
+        # of pandas (pandas 3.0),
+        # (to allow more performant data types, such as the Arrow string type, and
+        # better interoperability with other libraries)
+        # but was not found to be installed on your system.
+        # If this would cause problems for you,
+        # please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
+        import pandas

--- a/src/orquestra/integrations/cirq/conversions/_cirq_pauli_conversions.py
+++ b/src/orquestra/integrations/cirq/conversions/_cirq_pauli_conversions.py
@@ -1,13 +1,14 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
+from .._pandas_compat import preload_pandas_without_warnings
+
+preload_pandas_without_warnings()
+
 import warnings
 from typing import List, Optional, Union
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    # Pandas throws deprecation warning related to pyarrow
-    import cirq
+import cirq
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -35,7 +36,6 @@ def pauliop_to_cirq_paulisum(
 
     converted_sum = cirq.PauliSum()
     for term in pauli_operator.terms:
-
         # Identity term
         if term.is_constant:
             converted_sum += term.coefficient

--- a/tests/orquestra/integrations/cirq/conversions/circuit_conversions_test.py
+++ b/tests/orquestra/integrations/cirq/conversions/circuit_conversions_test.py
@@ -1,12 +1,11 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
-import warnings
+from orquestra.integrations.cirq._pandas_compat import preload_pandas_without_warnings
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    # Pandas throws deprecation warning related to pyarrow
-    import cirq
+preload_pandas_without_warnings()
+
+import cirq
 
 import numpy as np
 import pytest

--- a/tests/orquestra/integrations/cirq/conversions/openfermion_conversions_test.py
+++ b/tests/orquestra/integrations/cirq/conversions/openfermion_conversions_test.py
@@ -1,14 +1,13 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
-import warnings
+from orquestra.integrations.cirq._pandas_compat import preload_pandas_without_warnings
+
+preload_pandas_without_warnings()
 
 import pytest
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    # Pandas throws deprecation warning related to pyarrow
-    from openfermion import IsingOperator, QubitOperator  # type: ignore
+from openfermion import IsingOperator, QubitOperator  # type: ignore
 
 from openfermion.testing import random_qubit_operator  # type: ignore
 from orquestra.quantum.operators import PauliSum, PauliTerm

--- a/tests/orquestra/integrations/cirq/decompositions/cirq_decomposition_test.py
+++ b/tests/orquestra/integrations/cirq/decompositions/cirq_decomposition_test.py
@@ -1,12 +1,11 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
-import warnings
+from orquestra.integrations.cirq._pandas_compat import preload_pandas_without_warnings
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    # Pandas throws deprecation warning related to pyarrow
-    import cirq
+preload_pandas_without_warnings()
+
+import cirq
 
 import numpy as np
 import pytest

--- a/tests/orquestra/integrations/cirq/noise/basic_test.py
+++ b/tests/orquestra/integrations/cirq/noise/basic_test.py
@@ -1,14 +1,13 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
+from orquestra.integrations.cirq._pandas_compat import preload_pandas_without_warnings
+
+preload_pandas_without_warnings()
+
 import os
-import warnings
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    # Pandas throws deprecation warning related to pyarrow
-    import cirq
-
+import cirq
 import pytest
 
 from orquestra.integrations.cirq.noise.basic import (

--- a/tests/orquestra/integrations/cirq/simulator/simulator_test.py
+++ b/tests/orquestra/integrations/cirq/simulator/simulator_test.py
@@ -1,15 +1,13 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
-import warnings
+from orquestra.integrations.cirq._pandas_compat import preload_pandas_without_warnings
+
+preload_pandas_without_warnings()
 
 import numpy as np
 import pytest
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    # Pandas throws deprecation warning related to pyarrow
-    from cirq import depolarize
+from cirq import depolarize
 
 from orquestra.quantum.api.circuit_runner_contracts import (
     CIRCUIT_RUNNER_CONTRACTS,


### PR DESCRIPTION
## Description

Inspired while reviewing https://github.com/zapatacomputing/orquestra-cirq/pull/53. We import `cirq`, `cirq` imports `pandas`, `pandas` raises `DeprecationWarnings`. The original workaround was to just silence warnings when importing `cirq`. This PR makes the silencing localized to `pandas`. This way we won't miss future deprecation warnings raised by `cirq`.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
