### PR TITLE
Removing cirq-google and loosening cirq-core version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,7 @@ python_requires = >=3.9,!=3.9.7
 install_requires =
     #This is to fix unbounded dependency in cirq 0.13
     protobuf<4
-    cirq-core~=1.3.0
-    cirq-google~=1.3.0
+    cirq-core~=1.2
     orquestra-quantum
     openfermion~=1.6.0
 


### PR DESCRIPTION
## Description

This PR addresses dependency conflicts with pyliqtr v1.2.0 by removing an unnecessary dependency on cirq-google and loosening the version requirements for cirq-core.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
